### PR TITLE
Remove AWS dependency for schema fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ This tool analyzes CloudFormation templates to identify all resource types used,
 ## Prerequisites
 
 - Python 3.9+
-- AWS CLI configured (only required for IAM role creation with `-c` flag)
 - [uv package manager](https://docs.astral.sh/uv/getting-started/installation/)
+- boto3 (only required for IAM role creation with `-c` flag): `pip install boto3`
 
 ## Installation
 
 ```bash
 pip install cfn2iam
+```
+
+For IAM role creation functionality:
+```bash
+pip install cfn2iam[iam]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This tool analyzes CloudFormation templates to identify all resource types used,
 ## Prerequisites
 
 - Python 3.9+
-- AWS CLI configured with [CloudFormation DescribeType](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeType.html) permission
+- AWS CLI configured (only required for IAM role creation with `-c` flag)
 - [uv package manager](https://docs.astral.sh/uv/getting-started/installation/)
 
 ## Installation
@@ -67,7 +67,7 @@ cfn2iam path/to/template.yaml -p arn:aws:iam::123456789012:policy/boundary
 ## How It Works
 
 1. The tool parses the CloudFormation template to extract all resource types
-2. For each resource type, it queries the CloudFormation registry to get the required permissions
+2. For each resource type, it fetches the schema from pre-hosted GitHub schemas (https://mrlikl.github.io/cfn2iam/backend/schemas/)
 3. It categorizes permissions into "update" (create/update/read) and "delete-specific" permissions
 4. It generates a policy document with appropriate Allow and Deny statements
 5. It saves the policy document to a file with a unique name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ license-files = [
 ]
 keywords = ["aws, cloudformation, iam, permissions"]
 dependencies = [
-    "boto3",
     "pyyaml",
     "typer"
 ]
 requires-python = ">=3.9"
+
+[project.optional-dependencies]
+iam = ["boto3"]
 
 [project.urls]
 Homepage = "https://github.com/mrlikl/cfn2iam.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license-files = [
 ]
 keywords = ["aws, cloudformation, iam, permissions"]
 dependencies = [
-    "botocore",
+    "boto3",
     "pyyaml",
     "typer"
 ]

--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,64 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Example CloudFormation template for cfn2iam",
+  "Resources": {
+    "MyS3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": "my-example-bucket-12345",
+        "VersioningConfiguration": { "Status": "Enabled" }
+      }
+    },
+    "MyLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "FunctionName": "MyExampleFunction",
+        "Runtime": "python3.9",
+        "Handler": "index.handler",
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'statusCode': 200, 'body': 'Hello World'}"
+        },
+        "Role": { "Fn::GetAtt": ["MyLambdaRole", "Arn"] }
+      }
+    },
+    "MyLambdaRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Service": "lambda.amazonaws.com" },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ]
+      }
+    },
+    "MyDynamoDBTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "TableName": "MyExampleTable",
+        "AttributeDefinitions": [
+          { "AttributeName": "id", "AttributeType": "S" }
+        ],
+        "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+        "BillingMode": "PAY_PER_REQUEST"
+      }
+    }
+  },
+  "Outputs": {
+    "BucketName": {
+      "Description": "Name of the S3 bucket",
+      "Value": { "Ref": "MyS3Bucket" }
+    },
+    "FunctionArn": {
+      "Description": "ARN of the Lambda function",
+      "Value": { "Fn::GetAtt": ["MyLambdaFunction", "Arn"] }
+    }
+  }
+}

--- a/source/app.py
+++ b/source/app.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-import botocore.session
 import typer
 import json
 import yaml
 import sys
 import re
 import uuid
+import urllib.request
+import urllib.error
 from typing import Optional
 from importlib.metadata import version
 
@@ -66,10 +67,20 @@ def parse_cloudformation_template(file_path):
 
 
 def get_permissions(resourcetype):
-    session = botocore.session.get_session()
-    cfn_client = session.create_client('cloudformation')
-    response = cfn_client.describe_type(Type='RESOURCE', TypeName=resourcetype)
-    data = json.loads(response['Schema'])
+    # Convert resource type to filename format (AWS::S3::Bucket -> AWS_S3_Bucket.json)
+    filename = resourcetype.replace('::', '_') + '.json'
+    url = f'https://mrlikl.github.io/cfn2iam/backend/schemas/{filename}'
+    
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = json.loads(response.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"Warning: Schema not found for {resourcetype}")
+            return set(), set()
+        raise Exception(f"Failed to fetch schema for {resourcetype}: {e}")
+    except Exception as e:
+        raise Exception(f"Error processing schema for {resourcetype}: {e}")
 
     iam_update = set()
     iam_delete = set()
@@ -129,8 +140,8 @@ def generate_policy_document(all_update_permissions, all_delete_permissions, all
 
 
 def create_iam_role(policy_document, role_name, permissions_boundary=None):
-    session = botocore.session.get_session()
-    iam_client = session.create_client('iam')
+    import boto3
+    iam_client = boto3.client('iam')
     trust_policy = {
         "Version": "2012-10-17",
         "Statement": [

--- a/source/app.py
+++ b/source/app.py
@@ -140,7 +140,12 @@ def generate_policy_document(all_update_permissions, all_delete_permissions, all
 
 
 def create_iam_role(policy_document, role_name, permissions_boundary=None):
-    import boto3
+    try:
+        import boto3
+    except ImportError:
+        print("Error: boto3 is required for IAM role creation. Install with: pip install boto3")
+        return None
+        
     iam_client = boto3.client('iam')
     trust_policy = {
         "Version": "2012-10-17",

--- a/uv.lock
+++ b/uv.lock
@@ -39,17 +39,22 @@ wheels = [
 name = "cfn2iam"
 source = { editable = "." }
 dependencies = [
-    { name = "boto3" },
     { name = "pyyaml" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+iam = [
+    { name = "boto3" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "boto3" },
+    { name = "boto3", marker = "extra == 'iam'" },
     { name = "pyyaml" },
     { name = "typer" },
 ]
+provides-extras = ["iam"]
 
 [[package]]
 name = "click"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -7,8 +7,22 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.40.40"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/12/1a31b36802d0f33bc6982ab8b7e6437d75ef3c179abe6c53d4d8f7b4248f/boto3-1.40.40.tar.gz", hash = "sha256:f384d3a0410d0f1a4d4ae7aa69c41d0549c6ca5a76667dc25fc97d50ad6db740", size = 111606, upload-time = "2025-09-26T19:23:46.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/69/c65566dbdaaea3af0c23f7731ab0f185a38b593fd449d2423374150dbfe0/boto3-1.40.40-py3-none-any.whl", hash = "sha256:385904de68623e1c341bdc095d94a30006843032c912adeb1e0752a343632ec6", size = 139340, upload-time = "2025-09-26T19:23:45.557Z" },
+]
+
+[[package]]
 name = "botocore"
-version = "1.40.7"
+version = "1.40.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
@@ -16,23 +30,23 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/d7/5e559918410b259c1e54a4646ff39c56433e1c9cefa5e66ab0f06716cee8/botocore-1.40.7.tar.gz", hash = "sha256:33793696680cf3a0c4b5ace4f9070c67c4d4fcb19c999fd85cfee55de3dcf913", size = 14318282, upload-time = "2025-08-11T19:20:33.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/5a/43a7fea503ad14fa79819f2b3103a38977fb587a3663d1ac6e958fccf592/botocore-1.40.40.tar.gz", hash = "sha256:78eb121a16a6481ed0f6e1aebe53a4f23aa121f34466846c13a5ca48fa980e31", size = 14363370, upload-time = "2025-09-26T19:23:37.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/fa/bb7ec68b24d1b4678d341a305cbfed78a593e6383c86a70727410e4d0e11/botocore-1.40.7-py3-none-any.whl", hash = "sha256:a06956f3d7222e80ef6ae193608f358c3b7898e1a2b88553479d8f9737fbb03e", size = 13981488, upload-time = "2025-08-11T19:20:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/3bbf6d34cbf307c1b9e58e0204ceba2d35bbc0c93b4e3b3cc895aae0a5fd/botocore-1.40.40-py3-none-any.whl", hash = "sha256:68506142b3cde93145ef3ee0268f2444f2b68ada225a151f714092bbd3d6516a", size = 14031738, upload-time = "2025-09-26T19:23:35.475Z" },
 ]
 
 [[package]]
 name = "cfn2iam"
 source = { editable = "." }
 dependencies = [
-    { name = "botocore" },
+    { name = "boto3" },
     { name = "pyyaml" },
     { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "botocore" },
+    { name = "boto3" },
     { name = "pyyaml" },
     { name = "typer" },
 ]
@@ -210,6 +224,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace botocore with urllib for HTTP requests to GitHub hosted schemas
- Update get_permissions() to fetch from mrlikl.github.io/cfn2iam/backend/schemas/
- Change dependency from botocore to boto3 (only needed for IAM role creation)
- Update README to remove CloudFormation DescribeType permission requirement
- Add graceful error handling for missing schemas